### PR TITLE
refactor: Refactor type and client for improved functionality.

### DIFF
--- a/src/client/collectible.ts
+++ b/src/client/collectible.ts
@@ -39,6 +39,9 @@ export const CollectibleKeystoreClient = (axiosInstance: AxiosInstance, keystore
     return axiosInstance.post<unknown, CollectibleTransactionResponse>(`/collectibles/requests/${requestID}/${action}`, { pin: encrypted });
   };
 
+  const transfer = (action: MultisigInitAction, raw: string): Promise<CollectibleTransactionResponse> =>
+    axiosInstance.post<unknown, CollectibleTransactionResponse>('/collectibles/requests', { action, raw });
+
   return {
     /** Get the information of the collectible */
     fetch: (tokenID: string): Promise<CollectibleResponse> => axiosInstance.get<unknown, CollectibleResponse>(`/collectibles/tokens/${tokenID}`),
@@ -55,9 +58,11 @@ export const CollectibleKeystoreClient = (axiosInstance: AxiosInstance, keystore
       return axiosInstance.get<unknown, CollectibleOutputsResponse[]>('/collectibles/outputs', { params: hashedParams });
     },
 
+    /** @deprecated Use transfer() instead */
+    request: transfer,
+
     /** Create a collectibles transfer request */
-    request: (action: MultisigInitAction, raw: string): Promise<CollectibleTransactionResponse> =>
-      axiosInstance.post<unknown, CollectibleTransactionResponse>('/collectibles/requests', { action, raw }),
+    transfer,
 
     /** Initiate or participate in signing */
     sign: (pin: string, requestID: string) => manageRequest(pin, requestID, 'sign'),

--- a/src/client/payment.ts
+++ b/src/client/payment.ts
@@ -2,10 +2,16 @@ import { AxiosInstance } from 'axios';
 import { buildClient } from './utils/client';
 import { PaymentRequestResponse, RawTransactionRequest, TransferRequest } from './types';
 
-export const PaymentBaseClient = (axiosInstance: AxiosInstance) => ({
-  // Generate code id for transaction/transfer or verify payments by trace id
-  request: (params: TransferRequest | RawTransactionRequest) => axiosInstance.post<unknown, PaymentRequestResponse>('/payments', params),
-});
+export const PaymentBaseClient = (axiosInstance: AxiosInstance) => {
+  const payment = (params: TransferRequest | RawTransactionRequest) => axiosInstance.post<unknown, PaymentRequestResponse>('/payments', params);
+  return {
+    /** @deprecated Use payment() instead */
+    request: payment,
+
+    // Generate code id for transaction/transfer or verify payments by trace id
+    payment,
+  };
+};
 
 export const PaymentClient = buildClient(PaymentBaseClient);
 

--- a/src/client/types/asset.ts
+++ b/src/client/types/asset.ts
@@ -22,6 +22,7 @@ export interface AssetCommonResponse {
   capitalization: number;
   liquidity: string;
   reserve: string;
+  precision: number;
 }
 
 // fields for

--- a/src/client/types/code.ts
+++ b/src/client/types/code.ts
@@ -3,5 +3,6 @@ import { MultisigRequestResponse } from './multisig';
 import { CollectibleTransactionResponse } from './collectible';
 import { PaymentRequestResponse } from './payment';
 import { UserResponse } from './user';
+import { AuthorizationResponse } from './oauth';
 
-export type CodeResponse = ConversationResponse | MultisigRequestResponse | CollectibleTransactionResponse | PaymentRequestResponse | UserResponse;
+export type CodeResponse = ConversationResponse | MultisigRequestResponse | CollectibleTransactionResponse | PaymentRequestResponse | UserResponse | AuthorizationResponse;

--- a/src/client/types/multisig.ts
+++ b/src/client/types/multisig.ts
@@ -39,7 +39,7 @@ export interface MultisigUTXOResponse {
 }
 
 export interface MultisigRequestResponse {
-  type: string;
+  type: 'multisig_request';
   request_id: string;
   user_id: string;
   asset_id: string;

--- a/src/client/types/oauth.ts
+++ b/src/client/types/oauth.ts
@@ -23,6 +23,7 @@ export interface AuthorizeRequest {
 }
 
 export interface AuthorizationResponse {
+  type: 'authorization';
   authorization_id: string;
   authorization_code: string;
   scopes: OAuthScope[];

--- a/src/client/types/withdrawal.ts
+++ b/src/client/types/withdrawal.ts
@@ -1,7 +1,7 @@
 export interface WithdrawalRequest {
   address_id: string;
   amount: string;
-  pin_base64: string;
+  pin_base64?: string;
   fee?: string;
   trace_id?: string;
   memo?: string;


### PR DESCRIPTION
- Refactor PaymentBaseClient to deprecate the request function
- Make the pin_base64 field optional in WithdrawalRequest interface
- Add precision field to AssetCommonResponse in asset.ts
- Add new types to `CodeResponse` and `AuthorizationResponse` interfaces
- Change `type` value in `MultisigRequestResponse` interface
- Deprecate old `request` function and add new `transfer` function to `CollectibleKeystoreClient`