### PR TITLE
Fix memo in withdrawal example

### DIFF
--- a/example/safe_withdraw.js
+++ b/example/safe_withdraw.js
@@ -13,6 +13,7 @@ const keystore = require('../keystore.json');
 
 const withdrawal_asset_id = 'b91e18ff-a9ae-3dc7-8679-e935d9a4b34b';
 const withdrawal_amount = '1';
+const withdrawal_memo = 'memo';
 const withdrawal_destination = '';
 const spendPrivateKey = '';
 
@@ -44,6 +45,7 @@ const main = async () => {
       {
         amount: withdrawal_amount,
         destination: withdrawal_destination,
+        tag: withdrawal_memo,
       },
     ];
     const { utxos, change } = getUnspentOutputsForRecipients(outputs, recipients);
@@ -63,7 +65,7 @@ const main = async () => {
         })),
     );
     // spare the 0 inedx for withdrawal output, withdrawal output doesnt need ghost key
-    const tx = buildSafeTransaction(utxos, recipients, [undefined, ...ghosts], 'withdrawal-memo');
+    const tx = buildSafeTransaction(utxos, recipients, [undefined, ...ghosts], 'mainnet-transaction-extra');
     console.log(tx);
     const raw = encodeSafeTransaction(tx);
     const ref = blake3Hash(Buffer.from(raw, 'hex')).toString('hex');
@@ -84,7 +86,7 @@ const main = async () => {
         index: i,
       })),
     );
-    const feeTx = buildSafeTransaction(feeUtxos, feeRecipients, feeGhosts, 'withdrawal-fee-memo', [ref]);
+    const feeTx = buildSafeTransaction(feeUtxos, feeRecipients, feeGhosts, 'mainnet-fee-transaction-extra', [ref]);
     console.log(feeTx);
     const feeRaw = encodeSafeTransaction(feeTx);
     console.log(feeRaw);
@@ -130,6 +132,7 @@ const main = async () => {
       {
         amount: withdrawal_amount,
         destination: withdrawal_destination,
+        tag: withdrawal_memo,
       },
       // fee output
       buildSafeTransactionRecipient([MixinCashier], 1, fee.amount),
@@ -151,7 +154,7 @@ const main = async () => {
         })),
     );
     // spare the 0 inedx for withdrawal output, withdrawal output doesnt need ghost key
-    const tx = buildSafeTransaction(utxos, recipients, [undefined, ...ghosts], 'withdrawal-memo');
+    const tx = buildSafeTransaction(utxos, recipients, [undefined, ...ghosts], 'mainnet-transaction-extra');
     console.log(tx);
     const raw = encodeSafeTransaction(tx);
 


### PR DESCRIPTION
withdrawal-memo in buildSafeTransaction is not the actual withdrawal memo. It only exists in Mixin mainnet.

e.g. For a EOS transaction. If you specify the memo in the field of 'withdrawal-memo' (which is an argument of buildSafeTransaction), you won't receive your fund on the other side. It turns out you can only set the memo in 'recipients' to initiate a successful withdrawal. 

Failed example (No Memo):
https://mixin.space/tx/c4c145e3d8c562b13002cc080cfdd5b89a6978a877fcc678ddbd3f7d978965f5 
https://eosflare.io/tx/FE73D7CCC4319C4EA931657CA402C57886F4AF87203AAA9B7E8FE183ECD8EEF2

Success example (With Memo): 
https://mixin.space/tx/4430151efdb35cc26b6863e7048417beb3ad88e3b45149efdb55d73f576bdd26 
https://eosflare.io/tx/8CDB5B8DBB97718FDB5B71570B9316AACCB1E0D59BD2841EDCE8EC66057A90A3