### PR TITLE
fix(oauth): make ed25519 optional and add access_token to AccessTokenResponse

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mixin.dev/mixin-node-sdk",
-  "version": "7.5.2",
+  "version": "7.5.3",
   "license": "MIT",
   "description": "Mixin SDK for Node.js and Javascript",
   "main": "dist/index.js",

--- a/src/client/types/oauth.ts
+++ b/src/client/types/oauth.ts
@@ -6,12 +6,14 @@ export interface AccessTokenResponse {
   scope: string;
   authorization_id: string;
   /** public key from server */
-  ed25519: string;
+  ed25519?: string;
+  access_token?: string;
 }
+
 export interface AccessTokenRequest {
   client_id: string;
   code: string;
-  ed25519: string;
+  ed25519?: string;
   client_secret?: string;
   code_verifier?: string;
 }


### PR DESCRIPTION
## Problem

The backend OAuth flow (using `client_secret`) does not use an ed25519 keypair and returns an `access_token` JWT in the response — not a server `ed25519` key. However, the existing types forced callers into the PKCE shape:

- `AccessTokenRequest.ed25519` was required, blocking `{ client_id, client_secret, code }` without `as any`
- `AccessTokenResponse` had no `access_token` field, so callers couldn't read it without a cast

## Changes

Minimal, backward-compatible field changes only — no type renames, no new interfaces:

- `AccessTokenRequest.ed25519`: `string` → `string?` (required → optional)
- `AccessTokenResponse.ed25519`: `string` → `string?` (required → optional)
- `AccessTokenResponse.access_token`: added as `string?`

## Before

```ts
// had to cast as any for backend flow
const resp = await (client.oauth.getToken as any)({ client_id, client_secret, code });
const token: string = resp.access_token;
```

## After

```ts
// fully typed, no cast needed
const resp = await client.oauth.getToken({ client_id, client_secret, code });
resp.access_token; // string | undefined
```

Existing PKCE callers are unaffected — passing `ed25519` still works as before.