### PR TITLE
Fix WebView asset callbacks

### DIFF
--- a/src/webview/client.ts
+++ b/src/webview/client.ts
@@ -62,29 +62,40 @@ export const WebViewApi = () => {
       }
     },
 
-    getAssets: async (assets: string[], cb: (assets: WebviewAsset[]) => void) => {
-      const cbf = (str: string) => {
-        const assets = JSON.parse(str) as WebviewAsset[];
-        cb(assets);
-      };
-      switch (getMixinContext().platform) {
-        case 'iOS':
-          if (window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.getAssets) {
-            window.assetsCallbackFunction = cbf;
-            await window.webkit.messageHandlers.getAssets.postMessage([assets, 'assetsCallbackFunction']);
+    getAssets: (assets: string[], cb: (assets: WebviewAsset[]) => void) =>
+      new Promise<void>((resolve, reject) => {
+        const callbackName = `mixinAssetsCallback_${Date.now()}_${Math.random().toString(36).slice(2)}`;
+        const callbacks = window as unknown as Record<string, ((response: string) => void) | undefined>;
+
+        callbacks[callbackName] = response => {
+          delete callbacks[callbackName];
+
+          try {
+            cb(JSON.parse(response) as WebviewAsset[]);
+            resolve();
+          } catch (error) {
+            reject(error);
           }
-          break;
-        case 'Android':
-        case 'Desktop':
+        };
+
+        try {
+          if (window.webkit?.messageHandlers?.getAssets) {
+            window.webkit.messageHandlers.getAssets.postMessage([assets, callbackName]);
+            return;
+          }
+
           if (window.MixinContext && typeof window.MixinContext.getAssets === 'function') {
-            window.assetsCallbackFunction = cbf;
-            await window.MixinContext.getAssets(assets, 'assetsCallbackFunction');
+            window.MixinContext.getAssets(assets, callbackName);
+            return;
           }
-          break;
-        default:
-          break;
-      }
-    },
+
+          delete callbacks[callbackName];
+          resolve();
+        } catch (error) {
+          delete callbacks[callbackName];
+          reject(error);
+        }
+      }),
 
     getTipAddress: async (chainId: string, cb: (address: string) => void) => {
       switch (getMixinContext().platform) {

--- a/test/webview.test.ts
+++ b/test/webview.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { WebViewApi } from '../src/webview';
+
+const assets = [
+  {
+    asset_id: '43d61dcd-e413-450d-80b8-101d5e903357',
+    balance: '1',
+    chain_id: '43d61dcd-e413-450d-80b8-101d5e903357',
+    icon_url: '',
+    name: 'Ethereum',
+    symbol: 'ETH',
+  },
+];
+
+type TestWindow = Window & Record<string, unknown>;
+
+describe('WebViewApi.getAssets', () => {
+  let testWindow: TestWindow;
+
+  beforeEach(() => {
+    testWindow = {} as TestWindow;
+    Object.assign(globalThis, { window: testWindow });
+  });
+
+  afterEach(() => {
+    delete (globalThis as { window?: unknown }).window;
+  });
+
+  it('waits for the Android callback and preserves the bridge receiver', async () => {
+    let callbackName = '';
+    const bridge = {
+      getAssets(this: unknown, assetIDs: string[], callback: string) {
+        expect(this).toBe(bridge);
+        expect(assetIDs).toEqual(['asset-id']);
+        callbackName = callback;
+      },
+    };
+    testWindow.MixinContext = bridge;
+    const callback = vi.fn();
+
+    const completion = WebViewApi().getAssets(['asset-id'], callback);
+
+    expect(callback).not.toHaveBeenCalled();
+    expect(callbackName).toMatch(/^mixinAssetsCallback_\d+_[a-z0-9]+$/);
+
+    const nativeCallback = testWindow[callbackName] as (response: string) => void;
+    nativeCallback(JSON.stringify(assets));
+
+    await expect(completion).resolves.toBeUndefined();
+    expect(callback).toHaveBeenCalledWith(assets);
+    expect(testWindow[callbackName]).toBeUndefined();
+  });
+
+  it('uses the iOS handler without requiring a MixinContext response first', async () => {
+    let callbackName = '';
+    testWindow.webkit = {
+      messageHandlers: {
+        getAssets: {
+          postMessage: ([assetIDs, callback]) => {
+            expect(assetIDs).toEqual(['asset-id']);
+            callbackName = callback;
+          },
+        },
+      },
+    };
+    const callback = vi.fn();
+
+    const completion = WebViewApi().getAssets(['asset-id'], callback);
+
+    expect(callbackName).toMatch(/^mixinAssetsCallback_\d+_[a-z0-9]+$/);
+
+    const nativeCallback = testWindow[callbackName] as (response: string) => void;
+    nativeCallback(JSON.stringify(assets));
+
+    await expect(completion).resolves.toBeUndefined();
+    expect(callback).toHaveBeenCalledWith(assets);
+    expect(testWindow[callbackName]).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- wait for the native asset callback before resolving WebViewApi().getAssets
- use a per-request callback name and remove it after delivery
- invoke the iOS and Android bridges directly while preserving the Android bridge receiver

## Testing
- npm test -- test/webview.test.ts
- npx tsc --noEmit
- npm run lint
- npm run build